### PR TITLE
Remove números da home e adiciona busca global

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -999,6 +999,108 @@ def get_conteudos_stats():
     })
 
 
+@app.route('/api/search', methods=['GET'])
+def global_search():
+    """Busca global em palestras, exercícios, estudos e cartilhas"""
+    q = request.args.get('q', '').strip()
+    if not q or len(q) < 2:
+        return jsonify({"results": [], "total": 0})
+
+    search_term = f'%{q}%'
+
+    # Buscar palestras
+    palestras = query_all("""
+        SELECT b.id, t.title, b.speaker, t.affiliation, t.date_time,
+               b.subcategory
+        FROM blog_blog_translation t
+        JOIN blog_blog b ON b.id = t.master_id
+        WHERE t.language_code = 'pt-br'
+          AND (t.title ILIKE %s OR b.speaker ILIKE %s
+               OR t.affiliation ILIKE %s OR t.body ILIKE %s)
+        ORDER BY t.date_time DESC
+        LIMIT 10
+    """, (search_term, search_term, search_term, search_term))
+
+    # Buscar exercícios
+    exercicios = query_all("""
+        SELECT id, title, description, instructor, published_date
+        FROM exercicios
+        WHERE title ILIKE %s OR description ILIKE %s
+              OR instructor ILIKE %s OR body ILIKE %s
+        ORDER BY published_date DESC
+        LIMIT 10
+    """, (search_term, search_term, search_term, search_term))
+
+    # Buscar estudos
+    estudos = query_all("""
+        SELECT id, title, description, author, published_date
+        FROM estudos
+        WHERE title ILIKE %s OR description ILIKE %s
+              OR author ILIKE %s OR body ILIKE %s
+        ORDER BY published_date DESC
+        LIMIT 10
+    """, (search_term, search_term, search_term, search_term))
+
+    # Buscar cartilhas
+    cartilhas = query_all("""
+        SELECT lf.id, t.title, t.body as description, b.speaker,
+               t.date_time as published_date
+        FROM blog_lecturefile lf
+        JOIN blog_blog_translation t ON t.master_id = lf.blog_post_id AND t.language_code = 'pt-br'
+        JOIN blog_blog b ON b.id = lf.blog_post_id
+        WHERE t.title ILIKE %s OR t.body ILIKE %s OR b.speaker ILIKE %s
+        ORDER BY t.date_time DESC
+        LIMIT 10
+    """, (search_term, search_term, search_term))
+
+    results = []
+
+    for r in palestras:
+        results.append({
+            "id": r['id'],
+            "type": "palestra",
+            "title": r['title'],
+            "subtitle": r['speaker'] or r['affiliation'] or '',
+            "date": r['date_time'].isoformat() if r['date_time'] else None,
+            "link": f"/conteudos/palestras/{r['id']}"
+        })
+
+    for r in exercicios:
+        results.append({
+            "id": r['id'],
+            "type": "exercicio",
+            "title": r['title'] or '',
+            "subtitle": r['instructor'] or r['description'] or '',
+            "date": r['published_date'].isoformat() if r['published_date'] else None,
+            "link": f"/conteudos/exercicios/{r['id']}"
+        })
+
+    for r in estudos:
+        results.append({
+            "id": r['id'],
+            "type": "estudo",
+            "title": r['title'] or '',
+            "subtitle": r['author'] or r['description'] or '',
+            "date": r['published_date'].isoformat() if r['published_date'] else None,
+            "link": f"/conteudos/estudos/{r['id']}"
+        })
+
+    for r in cartilhas:
+        results.append({
+            "id": r['id'],
+            "type": "cartilha",
+            "title": r['title'] or 'Cartilha',
+            "subtitle": r['speaker'] or '',
+            "date": r['published_date'].isoformat() if r['published_date'] else None,
+            "link": f"/conteudos/cartilhas/{r['id']}"
+        })
+
+    # Ordenar por data (mais recentes primeiro)
+    results.sort(key=lambda x: x['date'] or '', reverse=True)
+
+    return jsonify({"results": results, "total": len(results)})
+
+
 @app.route('/api/pages', methods=['GET'])
 def get_pages():
     """Retorna páginas estáticas"""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { Blog } from './pages/Blog';
 import { PalestraDetail } from './pages/PalestraDetail';
 import { Page } from './pages/Page';
 import { PesquisadorForm } from './pages/PesquisadorForm';
+import { SearchResults } from './pages/SearchResults';
 
 // Páginas de Conteúdos
 import { ExerciciosList } from './pages/conteudos/ExerciciosList';
@@ -36,6 +37,7 @@ function App() {
           <Route path="/" element={<Layout />}>
             <Route index element={<Home />} />
             <Route path="cadastro-pesquisador" element={<PesquisadorForm />} />
+            <Route path="search" element={<SearchResults />} />
 
             {/* Rota Admin (protegida) */}
             <Route path="admin" element={

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -14,7 +14,7 @@ export function Layout() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchQuery.trim()) {
-      navigate(`/blog?search=${encodeURIComponent(searchQuery.trim())}`);
+      navigate(`/search?q=${encodeURIComponent(searchQuery.trim())}`);
       setSearchQuery('');
       setMobileMenuOpen(false);
     }
@@ -144,7 +144,7 @@ export function Layout() {
               <div className="relative">
                 <input
                   type="text"
-                  placeholder="Buscar palestras..."
+                  placeholder="Buscar conteúdos..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="w-64 px-4 py-2 pl-10 rounded-full border-2 border-[#E6E6FA] focus:border-[#A8DADC] focus:outline-none focus:ring-2 focus:ring-[#A8DADC]/20 transition-all"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,19 +4,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Logo } from '@/components/Logo';
-import { Users, Video, BookOpen, ArrowRight, Play, ChevronLeft, ChevronRight, Mail, Phone, User, Heart, Dumbbell, FileText } from 'lucide-react';
-import { API_ENDPOINTS, API_BASE_URL } from '@/config/api';
-
-interface Stats {
-  total_usuarios: number;
-  total_palestras: number;
-  total_videos: number;
-  total_exercicios: number;
-  total_estudos: number;
-  total_cartilhas: number;
-  total_conteudos: number;
-  usuarios_por_tipo: Record<string, number>;
-}
+import { Video, BookOpen, ArrowRight, Play, ChevronLeft, ChevronRight, Mail, Phone, User, Heart, Users } from 'lucide-react';
+import { API_BASE_URL } from '@/config/api';
 
 interface LatestVideo {
   id: number;
@@ -29,7 +18,6 @@ interface LatestVideo {
 }
 
 export function Home() {
-  const [stats, setStats] = useState<Stats | null>(null);
   const [latestVideos, setLatestVideos] = useState<LatestVideo[]>([]);
   const [currentSlide, setCurrentSlide] = useState(0);
 
@@ -87,12 +75,6 @@ export function Home() {
   };
 
   useEffect(() => {
-    // Carregar estatísticas
-    fetch(API_ENDPOINTS.stats)
-      .then(res => res.json())
-      .then(data => setStats(data))
-      .catch(err => console.error('Erro ao carregar estatísticas:', err));
-
     // Carregar 6 vídeos mais recentes de todas as categorias
     fetch(`${API_BASE_URL}/api/latest-videos?limit=6`)
       .then(res => res.json())
@@ -165,89 +147,6 @@ export function Home() {
         </div>
       </section>
 
-      {/* Stats Section */}
-      {stats && (
-        <section className="py-16 px-4 bg-white">
-          <div className="container mx-auto max-w-6xl">
-            <div className="text-center mb-10">
-              <h2 className="text-3xl font-bold text-primary mb-2">Nossos Números</h2>
-              <p className="text-muted-foreground">Conteúdo disponível para você</p>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6">
-              {/* Card Usuários */}
-              <Card className="border-2 border-[#E6E6FA] hover:shadow-lg transition-shadow">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Usuários</CardTitle>
-                  <Users className="h-5 w-5 text-muted-foreground" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-3xl font-bold text-primary">{stats.total_usuarios.toLocaleString('pt-BR')}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Membros ativos
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* Card Palestras */}
-              <Card className="border-2 border-[#E6E6FA] hover:shadow-lg transition-shadow">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Palestras</CardTitle>
-                  <Play className="h-5 w-5 text-muted-foreground" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-3xl font-bold text-primary">{stats.total_palestras}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Vídeos educacionais
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* Card Exercícios */}
-              <Card className="border-2 border-[#E6E6FA] hover:shadow-lg transition-shadow">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Exercícios</CardTitle>
-                  <Dumbbell className="h-5 w-5 text-muted-foreground" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-3xl font-bold text-primary">{stats.total_exercicios}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Atividades físicas
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* Card Estudos */}
-              <Card className="border-2 border-[#E6E6FA] hover:shadow-lg transition-shadow">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Pesquisas</CardTitle>
-                  <BookOpen className="h-5 w-5 text-muted-foreground" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-3xl font-bold text-primary">{stats.total_estudos}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Artigos e materiais
-                  </p>
-                </CardContent>
-              </Card>
-
-              {/* Card Cartilhas */}
-              <Card className="border-2 border-[#E6E6FA] hover:shadow-lg transition-shadow">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Cartilhas</CardTitle>
-                  <FileText className="h-5 w-5 text-muted-foreground" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-3xl font-bold text-primary">{stats.total_cartilhas}</div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    PDFs disponíveis
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-        </section>
-      )}
 
       {/* Latest Videos Carousel Section */}
       {latestVideos.length > 0 && (

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Search, Play, Dumbbell, BookOpen, FileText, Calendar, ArrowRight } from 'lucide-react';
+import { API_BASE_URL } from '@/config/api';
+
+interface SearchResult {
+  id: number;
+  type: 'palestra' | 'exercicio' | 'estudo' | 'cartilha';
+  title: string;
+  subtitle: string;
+  date: string | null;
+  link: string;
+}
+
+const TYPE_CONFIG = {
+  palestra: { label: 'Palestra', icon: Play, color: 'bg-blue-100 text-blue-800' },
+  exercicio: { label: 'Exercício', icon: Dumbbell, color: 'bg-green-100 text-green-800' },
+  estudo: { label: 'Pesquisa', icon: BookOpen, color: 'bg-purple-100 text-purple-800' },
+  cartilha: { label: 'Cartilha', icon: FileText, color: 'bg-orange-100 text-orange-800' },
+};
+
+type ContentType = 'all' | 'palestra' | 'exercicio' | 'estudo' | 'cartilha';
+
+const FILTER_OPTIONS: { value: ContentType; label: string; icon: typeof Play }[] = [
+  { value: 'all', label: 'Todos', icon: Search },
+  { value: 'palestra', label: 'Palestras', icon: Play },
+  { value: 'exercicio', label: 'Exercícios', icon: Dumbbell },
+  { value: 'estudo', label: 'Pesquisas', icon: BookOpen },
+  { value: 'cartilha', label: 'Cartilhas', icon: FileText },
+];
+
+export function SearchResults() {
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('q') || '';
+  const [allResults, setAllResults] = useState<SearchResult[]>([]);
+  const [activeFilter, setActiveFilter] = useState<ContentType>('all');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!query || query.length < 2) {
+      setAllResults([]);
+      return;
+    }
+
+    setLoading(true);
+    setActiveFilter('all');
+    fetch(`${API_BASE_URL}/api/search?q=${encodeURIComponent(query)}`)
+      .then(res => res.json())
+      .then(data => {
+        setAllResults(data.results || []);
+      })
+      .catch(err => console.error('Erro na busca:', err))
+      .finally(() => setLoading(false));
+  }, [query]);
+
+  const filteredResults = activeFilter === 'all'
+    ? allResults
+    : allResults.filter(r => r.type === activeFilter);
+
+  const total = filteredResults.length;
+
+  // Contagem por tipo para mostrar nos botões
+  const counts = allResults.reduce((acc, r) => {
+    acc[r.type] = (acc[r.type] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const formatDate = (dateString: string | null) => {
+    if (!dateString) return '';
+    return new Date(dateString).toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="mb-12 text-center space-y-4">
+        <h1 className="text-4xl md:text-5xl font-bold text-primary">
+          Resultados da Busca
+        </h1>
+        {query && (
+          <div className="flex items-center justify-center gap-2 text-primary">
+            <Search className="w-5 h-5" />
+            <p className="text-lg font-medium">"{query}"</p>
+          </div>
+        )}
+        {!loading && (
+          <p className="text-sm text-muted-foreground">
+            {total} resultado{total !== 1 ? 's' : ''} encontrado{total !== 1 ? 's' : ''}
+          </p>
+        )}
+      </div>
+
+      {/* Filtros por tipo */}
+      {!loading && allResults.length > 0 && (
+        <div className="mb-8 flex justify-center gap-3 flex-wrap">
+          {FILTER_OPTIONS.map(({ value, label, icon: Icon }) => {
+            const count = value === 'all' ? allResults.length : (counts[value] || 0);
+            if (value !== 'all' && count === 0) return null;
+            return (
+              <Button
+                key={value}
+                variant={activeFilter === value ? 'default' : 'outline'}
+                onClick={() => setActiveFilter(value)}
+                className={`gap-2 ${activeFilter === value ? 'bg-primary' : 'border-2 border-[#E6E6FA]'}`}
+              >
+                <Icon className="w-4 h-4" />
+                {label}
+                <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                  activeFilter === value ? 'bg-white/20' : 'bg-[#E6E6FA]'
+                }`}>
+                  {count}
+                </span>
+              </Button>
+            );
+          })}
+        </div>
+      )}
+
+      {loading && (
+        <div className="text-center py-12">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Buscando...</p>
+        </div>
+      )}
+
+      {!loading && filteredResults.length > 0 && (
+        <div className="max-w-3xl mx-auto space-y-4">
+          {filteredResults.map((result) => {
+            const config = TYPE_CONFIG[result.type];
+            const Icon = config.icon;
+
+            return (
+              <Card key={`${result.type}-${result.id}`} className="hover:shadow-lg transition-shadow border-l-4 border-l-[#A8DADC]">
+                <CardHeader className="pb-2">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2 mb-2">
+                        <Badge className={`${config.color} border-0 gap-1`}>
+                          <Icon className="w-3 h-3" />
+                          {config.label}
+                        </Badge>
+                        {result.date && (
+                          <span className="text-xs text-muted-foreground flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {formatDate(result.date)}
+                          </span>
+                        )}
+                      </div>
+                      <CardTitle className="text-lg leading-tight">
+                        {result.title}
+                      </CardTitle>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between">
+                  {result.subtitle && (
+                    <p className="text-sm text-muted-foreground line-clamp-2 flex-1">
+                      {result.subtitle}
+                    </p>
+                  )}
+                  <Link to={result.link} className="flex-shrink-0 ml-4">
+                    <Button size="sm" className="gap-1">
+                      Ver
+                      <ArrowRight className="w-3 h-3" />
+                    </Button>
+                  </Link>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && query && filteredResults.length === 0 && (
+        <div className="text-center py-12">
+          <Search className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
+          <h3 className="text-xl font-semibold text-primary mb-2">
+            Nenhum resultado encontrado
+          </h3>
+          <p className="text-muted-foreground mb-6">
+            Tente buscar por outros termos
+          </p>
+          <Link to="/">
+            <Button variant="outline">Voltar ao início</Button>
+          </Link>
+        </div>
+      )}
+
+      {!loading && !query && (
+        <div className="text-center py-12">
+          <Search className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
+          <h3 className="text-xl font-semibold text-primary mb-2">
+            Digite um termo para buscar
+          </h3>
+          <p className="text-muted-foreground">
+            Busque em palestras, exercícios, pesquisas e cartilhas
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## O que muda

- Tirei a seção "Nossos Números" da página inicial porque os dados estavam desatualizados e não dá pra corrigir antes do lançamento dia 11
- A busca do site agora funciona de verdade: antes só buscava em palestras, agora busca em tudo (palestras, exercícios, estudos e cartilhas)
- Criei uma página de resultados com botões pra filtrar por tipo de conteúdo

## Como testar

- Abrir a home e conferir que a seção de números sumiu
- Digitar algo na barra de busca (ex: "parkinson") e ver se aparece resultados de todos os tipos
- Clicar nos botões de filtro e ver se filtra certinho